### PR TITLE
Change load_res_norm function to use isinstance

### DIFF
--- a/DeepMRSeg/data_augmentation.py
+++ b/DeepMRSeg/data_augmentation.py
@@ -87,7 +87,7 @@ def perturb_images( img,lab ):
 							stddev=randnoisestd, \
 							dtype=_tf.float32 ) ), \
 			lambda: img );
-	
+
 #	# add random gamma
 #	randcond  = _tf.random.uniform( [], 0, 2, dtype=_tf.int32 )
 #	randgamma = _tf.random.uniform( [], 0.9, 1.1, dtype=_tf.float32 )
@@ -121,7 +121,7 @@ def data_reader( filenames,reader_func,batch_size,mode ):
 
 	# Read TFRecords
 	ds = ds.map( map_func=reader_func, num_parallel_calls=_tf.data.experimental.AUTOTUNE )
-	print(ds)		
+	print(ds)
 
 	# Shuffle extracted data
 	if mode == _tf.estimator.ModeKeys.TRAIN:

--- a/DeepMRSeg/data_io.py
+++ b/DeepMRSeg/data_io.py
@@ -64,10 +64,10 @@ def load_res_norm( in_path,xy_width,ressize,orient='LPS',mask=0,rescalemethod='m
 	
 	### Load image if it is a file path
 	#IF
-	if _os.path.isfile(in_path):
+	if isinstance( in_path,str ):
 		FileRead = _nib.load( in_path )
 	### Else, verify if it is a nibabel object with a header
-	else:
+	elif isinstance( in_path,_nib.Nifti1Image ):
 		assert in_path.header
 		FileRead = in_path
 	#ENDIF

--- a/DeepMRSeg/deepmrseg_test.py
+++ b/DeepMRSeg/deepmrseg_test.py
@@ -146,7 +146,7 @@ class LoadModel():
 #DEF
 def extract_data_for_subject( otherImg=None,refImg=None,ressize=1, \
 			orient='LPS', xy_width=320, rescalemethod='minmax' ):
-	
+
 	### Load images
 	ref,_ = load_res_norm( refImg,xy_width,ressize,orient,mask=0,rescalemethod=rescalemethod )
 	others =[]

--- a/DeepMRSeg/deepmrseg_test.py
+++ b/DeepMRSeg/deepmrseg_test.py
@@ -202,7 +202,8 @@ def run_model( im_dat, num_classes, allmodels, bs ):
 	# ENDFOR EACH MODEL
 
 	### Reshuffle predictions from [z,x,y,c,m] -> [x,y,z,c,m]
-	ens = _np.moveaxis( val_prob,0,2 ).astype('float32').mean( axis=-1 )
+#	ens = _np.moveaxis( val_prob,0,2 ).astype('float32').mean( axis=-1 )
+	ens = _np.moveaxis( val_prob,0,2 ).mean( axis=-1 ).astype('float32')
 	del val_prob, im_dat_ds
 
 	return ens
@@ -216,7 +217,7 @@ def resample_ens( inImg,inImg_res_F,ens,ens_ref,c ):
 	import nibabel.processing as _nibp
 
 	ens_f = _nib.Nifti1Image( ens[ :,:,:,c ], inImg_res_F.affine, inImg_res_F.header )
-	ens_f_res = _nibp.resample_from_to( ens_f, inImg, order=1 ) #order=0 seems to produce the same results
+	ens_f_res = _nibp.resample_from_to( ens_f, inImg, order=0 ) #order=1 seems to produce the same results
 	ens_ref[ :,:,:,c ] = ens_f_res.get_data()
 
 	del ens_f, ens_f_res

--- a/DeepMRSeg/deepmrseg_train.py
+++ b/DeepMRSeg/deepmrseg_train.py
@@ -211,7 +211,7 @@ class Train(object):
 		self.mdlDir = FLAGS.mdlDir
 		self.max_to_keep = FLAGS.max_to_keep
 		self.summary = FLAGS.summary
-		
+
 		### Define Metrics
 		self.iou_train = _tf.keras.metrics.MeanIoU( num_classes=self.num_classes )
 		self.iou_val = _tf.keras.metrics.MeanIoU( num_classes=self.num_classes )

--- a/DeepMRSeg/layers.py
+++ b/DeepMRSeg/layers.py
@@ -86,7 +86,7 @@ def get_onehot( y,ls,xy,c ):
 							stddev=ls/2, \
 							dtype=_tf.float32 ) \
 					)
-		
+
 		return ( oh * (1 - rls) + 0.5 * rls )
 
 	else:

--- a/DeepMRSeg/models.py
+++ b/DeepMRSeg/models.py
@@ -27,14 +27,13 @@ def create_model( 	num_classes=2, \
 	#### INPUT LAYER ####
 	#####################
 	print("\n")
-		
-				
+
 #	# Defining placeholders
 	img_slice = _tf.keras.Input( dtype=_tf.float32, \
 					shape=[None,None,num_modalities], \
 					name="img_slice" )
 	print(img_slice)
-		
+
 	#####################
 	##### MAKE UNET #####
 	#####################

--- a/DeepMRSeg/preprocessImages_fcn.py
+++ b/DeepMRSeg/preprocessImages_fcn.py
@@ -88,7 +88,7 @@ def preprocessImage( T1Img=None, FLImg=None, dest=None, n_jobs=4, verbose=0, cos
 
 		if verbose == 1:
 			print(out)
-	       
+
 	except:
 		print("\nERROR! Execution of this command failed: \n", cmd)
 		print(err)

--- a/DeepMRSeg/pythonUtilities.py
+++ b/DeepMRSeg/pythonUtilities.py
@@ -26,7 +26,7 @@ def check_file(checkFileIP):
 ### Get File Attributes
 #DEF
 def file_att(FileAttIP):
-	
+
 	ACCEPTED_FILE_TYPES = [ 'nii.gz', 'hdr', 'img', 'nii' ]
 
 	if any( [FileAttIP.endswith(x) for x in ACCEPTED_FILE_TYPES] ):

--- a/DeepMRSeg/tfrecordutils.py
+++ b/DeepMRSeg/tfrecordutils.py
@@ -17,7 +17,7 @@ def _bytes_feature(value):
 	return _tf.train.Feature(bytes_list=_tf.train.BytesList(value=[value]))
 #ENDDEF
 
-#DEF			
+#DEF
 def tfrecordwriter( rname, rfeats, rlabels, feats_dtype, labels_dtype ):
 
 	# open the TFRecords file
@@ -35,7 +35,7 @@ def tfrecordwriter( rname, rfeats, rlabels, feats_dtype, labels_dtype ):
 
 		# Create an example protocol buffer
 		example = _tf.train.Example( features=_tf.train.Features(feature=feature) )
-        
+
 		# Serialize to string and write on the file
 		writer.write( example.SerializeToString() )
       


### PR DESCRIPTION
- Changed the if loop in load_res_norm to use isinstance instead of os.path.isfile
- Changed the order of averaging and casting in deepmrseg_test.py (run_model) to save memory
- Also changed the order of interpolation in resample_ens to save time
- Resolved some minor codacy issues
