### PR TITLE
Added instance check to save_output function

### DIFF
--- a/DeepMRSeg/data_io.py
+++ b/DeepMRSeg/data_io.py
@@ -3,7 +3,6 @@
 __author__ 	= 'Jimit Doshi'
 __EXEC_NAME__ 	= "data_io"
 
-import os as _os
 import numpy as _np
 
 from . import rescaleimages
@@ -34,11 +33,11 @@ def check_files( refImg=None, otherImg=None, labImg=None ):
 	if otherImg:
 		for m in range( len(otherImg) ):
 			others.extend( [ _nib.load( otherImg[m] ) ] )
-	
+
 	### Check if they have the same dimensions
 	if labImg:
 		assert lab.shape == ref.shape, "Shape misatch between %s and %s images" % ( labImg,refImg )
-	
+
 	if otherImg:
 		for m in range( len(otherImg) ):
 			assert others[m].shape == ref.shape, "Shape misatch between %s and %s images" % ( otherImg[m],refImg )
@@ -47,12 +46,12 @@ def check_files( refImg=None, otherImg=None, labImg=None ):
 	if labImg:
 		assert ( _np.round(lab.header.get_base_affine(),4) == _np.round(ref.header.get_base_affine(),4) ).all(), \
 						"Affine matrix misatch between %s and %s" % ( labImg,refImg )
-	
+
 	if otherImg:
 		for m in range( len(otherImg) ):
 			assert ( _np.round(others[m].header.get_base_affine(),4) == _np.round(ref.header.get_base_affine(),4) ).all(), \
 						"Affine matrix misatch between %s and %s" % ( otherImg[m],refImg )
-					
+
 #ENDDEF
 
 #DEF

--- a/DeepMRSeg/deepmrseg_test.py
+++ b/DeepMRSeg/deepmrseg_test.py
@@ -152,7 +152,7 @@ def extract_data_for_subject( otherImg=None,refImg=None,ressize=1, \
 	others =[]
 	for img in otherImg:
 		others.extend( [ load_res_norm( img,xy_width,ressize,orient,mask=0,rescalemethod=rescalemethod )[0] ] )
-	
+
 	### Restructure matrices from [x,y,z] to [z,x,y]
 	ref = _np.moveaxis( ref,2,0 )
 	for m in range( len(otherImg) ):
@@ -245,8 +245,15 @@ def save_output( ens, refImg, num_classes, roi_indices, out=None, probs=False, \
 	import nibabel as _nib
 	from concurrent.futures import ThreadPoolExecutor as _TPE
 
-	### Read reference image
-	inImg = _nib.load( refImg )
+	### Load reference image if it is a file path
+	#IF
+	if isinstance( refImg,str ):
+		inImg = _nib.load( refImg )
+	### Else, verify if it is a nibabel object with a header
+	elif isinstance( refImg,_nib.Nifti1Image ):
+		assert refImg.header
+		inImg = refImg
+	#ENDIF
 	
 	### Resample refImg
 	_,inImg_res_F = load_res_norm( in_path=refImg, \

--- a/DeepMRSeg/deepmrseg_train.py
+++ b/DeepMRSeg/deepmrseg_train.py
@@ -221,7 +221,7 @@ class Train(object):
 		self.epoch_train_ioul_avg = _tf.keras.metrics.Mean()
 		self.epoch_train_mael_avg = _tf.keras.metrics.Mean()
 		self.epoch_train_bcel_avg = _tf.keras.metrics.Mean()
-		
+
 		self.epoch_val_loss_avg = _tf.keras.metrics.Mean()
 		self.epoch_val_ioul_avg = _tf.keras.metrics.Mean()
 		self.epoch_val_mael_avg = _tf.keras.metrics.Mean()


### PR DESCRIPTION
This is to prevent an error when interfacing with MITK where the refImg is an sitk2nibabel object instead of a file path.