### PR TITLE
Reduced memory requirement for inference

### DIFF
--- a/DeepMRSeg/deepmrseg_test.py
+++ b/DeepMRSeg/deepmrseg_test.py
@@ -255,11 +255,11 @@ def save_output_probs( ens_ref,ind,roi,inImg,out ):
 	import nibabel as _nib
 
 	outImgDat = ens_ref[:,:,:,ind].copy()
-	outImgDat = outImgDat.astype('float16') / 255
+	outImgDat = outImgDat.astype('float32') / 255
 	outImgDat = _np.where( outImgDat<0.01, 0, outImgDat )
 
 	outImgDat_img = _nib.Nifti1Image( outImgDat, inImg.affine, inImg.header )
-	outImgDat_img.set_data_dtype( 'float16' )
+	outImgDat_img.set_data_dtype( 'float32' )
 	outImgDat_img.to_filename( _os.path.join( out[:-7] + '_probabilities_' + str(roi) + '.nii.gz' ) )
 #ENDDEF
 

--- a/DeepMRSeg/deepmrseg_test.py
+++ b/DeepMRSeg/deepmrseg_test.py
@@ -208,11 +208,12 @@ def load_model( models,cp ):
 def run_model( im_dat, num_classes, allmodels, bs ):
 
 	### Create array to store output probabilities
-	val_prob = _np.zeros( ( im_dat.shape[0:3] + (num_classes,len(allmodels)) ) )
+	# to reduce the memory requirement when working with many output classes
+	# shape: [z,x,y,c]
+	val_prob = _np.zeros( ( im_dat.shape[0:3] + (num_classes,) ),dtype='uint8' )
 
 	### Create a tf Dataset from im_dat
 	im_dat_ds = _tf.data.Dataset.from_tensor_slices( (im_dat) ).batch( bs )
-	
 
 	# Launch testing
 	# FOR EACH MODEL
@@ -221,14 +222,13 @@ def run_model( im_dat, num_classes, allmodels, bs ):
 		# FOR EACH BATCH OF SLICES
 		for one_batch in im_dat_ds:
 			bs = one_batch.shape[0]
-			val_prob[i:i+bs,:,:,:,c] = mod.run( one_batch )
+			val_prob[i:i+bs,:,:,:] += ( mod.run( one_batch ) / len(allmodels) * 255 ).astype('uint8')
 			i += bs
 		# ENDFOR EACH BATCH OF SLICES
 	# ENDFOR EACH MODEL
 
 	### Reshuffle predictions from [z,x,y,c,m] -> [x,y,z,c,m]
-#	ens = _np.moveaxis( val_prob,0,2 ).astype('float32').mean( axis=-1 )
-	ens = _np.moveaxis( val_prob,0,2 ).mean( axis=-1 ).astype('float32')
+	ens = _np.moveaxis( val_prob,0,2 )
 	del val_prob, im_dat_ds
 
 	return ens
@@ -255,10 +255,11 @@ def save_output_probs( ens_ref,ind,roi,inImg,out ):
 	import nibabel as _nib
 
 	outImgDat = ens_ref[:,:,:,ind].copy()
+	outImgDat = outImgDat.astype('float16') / 255
 	outImgDat = _np.where( outImgDat<0.01, 0, outImgDat )
 
 	outImgDat_img = _nib.Nifti1Image( outImgDat, inImg.affine, inImg.header )
-	outImgDat_img.set_data_dtype( 'float32' )
+	outImgDat_img.set_data_dtype( 'float16' )
 	outImgDat_img.to_filename( _os.path.join( out[:-7] + '_probabilities_' + str(roi) + '.nii.gz' ) )
 #ENDDEF
 
@@ -290,7 +291,7 @@ def save_output( ens, refImg, num_classes, roi_indices, out=None, probs=False, \
 					out_path=None )
 
 	### Re-orient, resample and resize ens to the refImg space
-	ens_ref = _np.zeros( (inImg.shape+(num_classes,)),dtype='float32' )
+	ens_ref = _np.zeros( (inImg.shape+(num_classes,)),dtype='uint8' )
 	#WITH
 	with _TPE( max_workers=nJobs ) as executor:
 		#FOR
@@ -344,6 +345,8 @@ def save_output( ens, refImg, num_classes, roi_indices, out=None, probs=False, \
 def predict_classes( refImg, otherImg, num_classes, allmodels, roi_indices, out=None, probs=False, \
 			rescalemethod='minmax', ressize=float(1), orient='LPS', xy_width=320, batch_size=64, nJobs=1 ):
 
+	print( "\t\t\t--> Extracting and pre-processing image data" )
+	_sys.stdout.flush()
 	im_dat = extract_data_for_subject( \
 			otherImg=otherImg, \
 			refImg=refImg, \
@@ -352,9 +355,13 @@ def predict_classes( refImg, otherImg, num_classes, allmodels, roi_indices, out=
 			xy_width=xy_width, \
 			rescalemethod=rescalemethod )
 
+	print( "\t\t\t--> Running inference" )
+	_sys.stdout.flush()
 	ens = run_model( im_dat=im_dat, num_classes=num_classes, \
 			allmodels=allmodels, bs=batch_size )
 
+	print( "\t\t\t--> Saving output" )
+	_sys.stdout.flush()
 	#IF OUTFILE PROVIDED
 	if out:
 		save_output( ens, refImg, num_classes, roi_indices, out=out, probs=probs, \

--- a/deepmrseg_singularity.def
+++ b/deepmrseg_singularity.def
@@ -1,0 +1,64 @@
+Bootstrap: docker
+From: tensorflow/tensorflow:2.3.3-gpu-jupyter
+
+%help
+
+	To install python libraries after this image is built, create a virtual environment that uses the system packages with `virtualenv --system-site-packages venv && source venv/bin/activate`, then use `pip` as usual.
+
+
+%environment
+
+%post
+	NOW=`env TZ=America/New_York date`
+	echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT
+
+%runscript
+	echo "\n\nContainer was created: $NOW"
+	echo "Python version: `python --version`"
+	echo "Python exec: `which python`"
+	echo "Arguments received: $*\n\n"
+	exec "$@"
+
+
+%post
+	export DEBIAN_FRONTEND=noninteractive
+	ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+	apt-get update
+	apt-get -y install python3-tk --fix-missing
+	
+	# need to create mount point for home dir, scratch
+	mkdir /uufs /scratch
+
+	pip install --upgrade setuptools
+%test
+	# Sanity check that the container is operating
+
+	# Test numpy 
+	python -c "import numpy as np;np.__config__.show()"
+
+	# Ensure that TensorFlow can be imported and session started (session start touches GPU)
+	python -c "import tensorflow as tf;s = tf.constant( 1.0, tf.float32 )"
+
+
+
+###############################
+### DEEPMRSEG
+###############################
+
+%environment        
+
+%post
+        echo "\n\n Installing DeepMRSeg \n\n"
+
+	mkdir -p /opt/cbica/src/deepmrseg \
+	&& cd /opt/cbica/src/deepmrseg \
+	&& git clone https://github.com/CBICA/DeepMRSeg.git \
+	&& cd DeepMRSeg \
+	&& python setup.py install \
+	&& rm -rf /opt/cbica/src/deepmrseg \
+	&& rmdir /opt/cbica/src /opt/cbica
+
+%test
+        echo "\nTesting DeepMRSeg exec(s)"
+        which deepmrseg_train
+	deepmrseg_train


### PR DESCRIPTION
Reduced the memory requirement for running inference by:
- changed the datatype for val_prob in run_model from ```float32``` to ```uint8```
- and changed the dimensionality of val_prob from ```[z,x,y,c,m]``` to ```[z,x,y,c]```
- while saving the output probabilities, they are converted back to ```float32``` and multiplied by 255.

Also added a singularity recipe/definition file for building deepmrseg.